### PR TITLE
pkg: switch Function package APIs from v1beta1 to v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This allows you to test the results of a Composition pipeline.
 Functions require Crossplane 1.14 or newer. Apply the following manifest to your cluster:
 
 ```yaml
-apiVersion: pkg.crossplane.io/v1beta1
+apiVersion: pkg.crossplane.io/v1
 kind: Function
 metadata:
   name: crossplane-contrib-function-unit-test

--- a/examples/basic-tests/function.yaml
+++ b/examples/basic-tests/function.yaml
@@ -1,11 +1,11 @@
-apiVersion: pkg.crossplane.io/v1beta1
+apiVersion: pkg.crossplane.io/v1
 kind: Function
 metadata:
   name: crossplane-contrib-function-patch-and-transform
 spec:
   package: xpkg.upbound.io/crossplane-contrib/function-patch-and-transform:v0.5.0
 ---
-apiVersion: pkg.crossplane.io/v1beta1
+apiVersion: pkg.crossplane.io/v1
 kind: Function
 metadata:
   name: crossplane-contrib-function-unit-test

--- a/package/crossplane.yaml
+++ b/package/crossplane.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: meta.pkg.crossplane.io/v1beta1
+apiVersion: meta.pkg.crossplane.io/v1
 kind: Function
 metadata:
   name: function-unit-test 


### PR DESCRIPTION
### Description

This PR updates Function package manifests to use `v1` instead of `v1beta1` for:

- `meta.pkg.crossplane.io`
- `pkg.crossplane.io`

Both `Function` and `FunctionRevision` already use `v1` as their storage version, so this change does not affect existing Crossplane installations when  Crossplane >= 1.17.x

The change only impacts newly built function packages, which will now be published using `v1`. Installing or upgrading these packages in an existing control plane works without disruption.

Related issue: https://github.com/crossplane/crossplane/issues/6947